### PR TITLE
#13 Use platform_system to exclude the netifaces dependency on windows

### DIFF
--- a/sdc11073/netconn/__init__.py
+++ b/sdc11073/netconn/__init__.py
@@ -1,9 +1,7 @@
 import os
 
 # OS dependent import
-if os.name == 'posix':
-    from .posixifmanager import getNetworkAdapterConfigs, GetAdaptersAddresses
-elif os.name == 'nt':
+if os.name == 'nt':
     from .ntifmanagerdll import getNetworkAdapterConfigs, GetAdaptersAddresses
 else:
-    raise Exception('netconn does not support os "%s"' % os.name)
+    from .posixifmanager import getNetworkAdapterConfigs, GetAdaptersAddresses

--- a/sdc11073/netconn/__init__.py
+++ b/sdc11073/netconn/__init__.py
@@ -1,7 +1,7 @@
-import os
+import platform
 
 # OS dependent import
-if os.name == 'nt':
+if platform.system() == 'Windows':
     from .ntifmanagerdll import getNetworkAdapterConfigs, GetAdaptersAddresses
 else:
     from .posixifmanager import getNetworkAdapterConfigs, GetAdaptersAddresses

--- a/sdc11073/netconn/posixifmanager.py
+++ b/sdc11073/netconn/posixifmanager.py
@@ -5,9 +5,9 @@ class Adapter():
     friendly_name = ""
     ip = ""
 
+
 def getNetworkAdapterConfigs():
     interfaces = netifaces.interfaces()
-    print(interfaces)
     adapters = []
     for ad in interfaces:
         addresses = netifaces.ifaddresses(ad)
@@ -21,7 +21,6 @@ def getNetworkAdapterConfigs():
 
 def GetAdaptersAddresses():
     interfaces = netifaces.interfaces()
-    print(interfaces)
     adapters = []
     for ad in interfaces:
         addresses = netifaces.ifaddresses(ad)

--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,12 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 dependencies = ['lxml>=2.3',
                 'lz4',
                 'cryptography',
-                'netifaces']
+                "netifaces ; platform_system!='Windows'"]
 
 
 setup(
     name='sdc11073',
-    version=version ,
+    version=version,
     description='pure python implementation of IEEE11073 SDC protocol',
     long_description=long_description,
     url='https://github.com/Draegerwerk/sdc11073',


### PR DESCRIPTION
#13 Use platform_system to exclude the netifaces dependency when running on windows, as it is unused there.

This flag is specified in PEP508.