### PR TITLE
Add support for setting LocationContext and EnsembleContext via SetContextStateOperation

### DIFF
--- a/sdc11073/roles/contextprovider.py
+++ b/sdc11073/roles/contextprovider.py
@@ -75,3 +75,8 @@ class GenericContextProvider(providerbase.ProviderRole):
 class EnsembleContextProvider(GenericContextProvider):
     def __init__(self, log_prefix):
         super(EnsembleContextProvider, self).__init__(opTargetDescriptorTypes=[namespaces.domTag('EnsembleContextDescriptor')], log_prefix=log_prefix)
+
+
+class LocationContextProvider(GenericContextProvider):
+    def __init__(self, log_prefix):
+        super(LocationContextProvider, self).__init__(opTargetDescriptorTypes=[namespaces.domTag('LocationContextDescriptor')], log_prefix=log_prefix)

--- a/sdc11073/roles/product.py
+++ b/sdc11073/roles/product.py
@@ -219,9 +219,7 @@ class GenericProduct(BaseProduct):
         super().__init__(log_prefix)
 
         self._ordered_providers.extend([audiopause_provider, daynight_provider, clock_provider])
-        self._ordered_providers.extend([contextprovider.EnsembleContextProvider(log_prefix=log_prefix),
-                                       contextprovider.LocationContextProvider(log_prefix=log_prefix),
-                                       patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
+        self._ordered_providers.extend([patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
                                        alarmprovider.GenericAlarmProvider(log_prefix=log_prefix),
                                        metricprovider.GenericMetricProvider(log_prefix=log_prefix),
                                        operationprovider.OperationProvider(log_prefix=log_prefix),
@@ -233,6 +231,19 @@ class MinimalProduct(BaseProduct):
     def __init__(self, log_prefix=None):
         super().__init__(log_prefix)
         self.metric_provider = metricprovider.GenericMetricProvider(log_prefix=log_prefix) # needed in a test
+        self._ordered_providers.extend([audiopauseprovider.GenericSDCAudioPauseProvider(log_prefix=log_prefix),
+                                       clockprovider.GenericSDCClockProvider(log_prefix=log_prefix),
+                                       patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
+                                       alarmprovider.GenericAlarmProvider(log_prefix=log_prefix),
+                                       self.metric_provider,
+                                       operationprovider.OperationProvider(log_prefix=log_prefix),
+                                       GenericSetComponentStateOperationProvider(log_prefix=log_prefix)
+        ])
+
+
+class ExtendedProduct(BaseProduct):
+    def __init__(self, log_prefix=None):
+        super().__init__(log_prefix)
         self._ordered_providers.extend([audiopauseprovider.GenericSDCAudioPauseProvider(log_prefix=log_prefix),
                                        clockprovider.GenericSDCClockProvider(log_prefix=log_prefix),
                                        contextprovider.EnsembleContextProvider(log_prefix=log_prefix),

--- a/sdc11073/roles/product.py
+++ b/sdc11073/roles/product.py
@@ -3,6 +3,7 @@ from . import alarmprovider
 from . import audiopauseprovider
 from . import clockprovider
 from . import metricprovider
+from . import contextprovider
 from . import patientcontextprovider
 from . import providerbase
 from .. import loghelper
@@ -218,7 +219,8 @@ class GenericProduct(BaseProduct):
         super().__init__(log_prefix)
 
         self._ordered_providers.extend([audiopause_provider, daynight_provider, clock_provider])
-        self._ordered_providers.extend([patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
+        self._ordered_providers.extend([contextprovider.EnsembleContextProvider(log_prefix=log_prefix),
+                                       patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
                                        alarmprovider.GenericAlarmProvider(log_prefix=log_prefix),
                                        metricprovider.GenericMetricProvider(log_prefix=log_prefix),
                                        operationprovider.OperationProvider(log_prefix=log_prefix),
@@ -232,6 +234,7 @@ class MinimalProduct(BaseProduct):
         self.metric_provider = metricprovider.GenericMetricProvider(log_prefix=log_prefix) # needed in a test
         self._ordered_providers.extend([audiopauseprovider.GenericSDCAudioPauseProvider(log_prefix=log_prefix),
                                        clockprovider.GenericSDCClockProvider(log_prefix=log_prefix),
+                                       contextprovider.EnsembleContextProvider(log_prefix=log_prefix),
                                        patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
                                        alarmprovider.GenericAlarmProvider(log_prefix=log_prefix),
                                        self.metric_provider,

--- a/sdc11073/roles/product.py
+++ b/sdc11073/roles/product.py
@@ -220,6 +220,7 @@ class GenericProduct(BaseProduct):
 
         self._ordered_providers.extend([audiopause_provider, daynight_provider, clock_provider])
         self._ordered_providers.extend([contextprovider.EnsembleContextProvider(log_prefix=log_prefix),
+                                       contextprovider.LocationContextProvider(log_prefix=log_prefix),
                                        patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
                                        alarmprovider.GenericAlarmProvider(log_prefix=log_prefix),
                                        metricprovider.GenericMetricProvider(log_prefix=log_prefix),
@@ -235,6 +236,7 @@ class MinimalProduct(BaseProduct):
         self._ordered_providers.extend([audiopauseprovider.GenericSDCAudioPauseProvider(log_prefix=log_prefix),
                                        clockprovider.GenericSDCClockProvider(log_prefix=log_prefix),
                                        contextprovider.EnsembleContextProvider(log_prefix=log_prefix),
+                                       contextprovider.LocationContextProvider(log_prefix=log_prefix),
                                        patientcontextprovider.GenericPatientContextProvider(log_prefix=log_prefix),
                                        alarmprovider.GenericAlarmProvider(log_prefix=log_prefix),
                                        self.metric_provider,


### PR DESCRIPTION
This fixes SetContextStateOperations regarding LocationContext and EnsembleContext not getting registered previously, now allowing the operation to be executed successfully.

However, I still encounter an issue: Instead of updating an existing Context, a new Context with a different handle is added.
This can conflict with the SDC standard, e.g. since only one LocationContextState is allowed.