### PR TITLE
Add missing attribute of range to __repr__

### DIFF
--- a/sdc11073/pmtypes.py
+++ b/sdc11073/pmtypes.py
@@ -505,7 +505,8 @@ class Range(PropertyBasedPMType):
         
         
     def __repr__(self):
-        return 'Range (Lower={!r}, Upper={!r})'.format(self.Lower, self.Upper)
+        return 'Range (Lower={!r}, Upper={!r}, StepWidth={!r}, RelativeAccuracy={!r}, AbsoluteAccuracy={!r})'\
+            .format(self.Lower, self.Upper, self.StepWidth, self.RelativeAccuracy, self.AbsoluteAccuracy)
 
 
 


### PR DESCRIPTION
This pull request will add missing attribute of the range class to __repr__