### PR TITLE
reorder catch clause in soapclient.py to avoid overly broad catch

### DIFF
--- a/sdc11073/pysoap/soapclient.py
+++ b/sdc11073/pysoap/soapclient.py
@@ -242,9 +242,6 @@ class SoapClient(CompressionHandler):
         def get_response():
             try:
                 return self._httpConnection.getresponse()
-            except httplib.BadStatusLine as ex:
-                self._log.warn("{}: invalid http response, error= {!r} ", msg, ex)
-                raise
             except OSError as ex:
                 if ex.errno in (10053, 10054):
                     self._log.warn("{}: could not receive response, OSError={!r}", msg, ex)
@@ -255,6 +252,9 @@ class SoapClient(CompressionHandler):
             except socket.error as ex:
                 self._log.warn("{}: could not receive response, socket error={!r}", msg, ex)
                 raise httplib.NotConnected()
+            except httplib.BadStatusLine as ex:
+                self._log.warn("{}: invalid http response, error= {!r} ", msg, ex)
+                raise
             except Exception as ex:
                 self._log.warn("{}: POST to netloc='{}' path='{}': could not receive response, error={!r}\n{}",
                                msg, self._netloc, path, ex, traceback.format_exc())


### PR DESCRIPTION
Catching `BadLineError` can overcatch and also grab `ConnectionResetError` exceptions. This a result of ugly multiple inheritance in Python itself, which introduced `RemoteDisconnected` as a parent exception to `BadLineError` _and_ `ConnectionResetError`, see https://docs.python.org/3/library/http.client.html#http.client.RemoteDisconnected

By reordering the except clauses, `ConnectionResetError` is once again properly caught by the `OSError` handler.