### PR TITLE
Fix iteration over types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the sdc11073 module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.19] - 2022-12-08
+### Fixed
+- iteration over DPWSHosted.types
+
+
 ## [1.1.18] - 2022-11-29
 ### Added
 - InstanceId is handled in mdib

--- a/sdc11073/sdcclient/sdcclientimpl.py
+++ b/sdc11073/sdcclient/sdcclientimpl.py
@@ -379,11 +379,12 @@ class SdcClient(object):
         # group subscriptions per hosted service
         for service_id, dpwsHosted in self.metaData.hosted.items():
             available_actions = []
-            for port_type_qname in dpwsHosted.types:
-                port_type = port_type_qname.split(':')[-1]
-                client = self.client(port_type)
-                if client is not None:
-                    available_actions.extend( client.getSubscribableActions())
+            if dpwsHosted.types:
+                for port_type_qname in dpwsHosted.types:
+                    port_type = port_type_qname.split(':')[-1]
+                    client = self.client(port_type)
+                    if client is not None:
+                        available_actions.extend( client.getSubscribableActions())
             if len(available_actions) > 0:
                 subscribe_actions = set(available_actions) - notSubscribedActionsSet
                 if not subscribe_periodic_reports:
@@ -489,7 +490,10 @@ class SdcClient(object):
             endpoint_reference = hosted.endpointReferences[0].address
             soapClient = self._getSoapClient(endpoint_reference)
             hosted.soapClient = soapClient
-            ns_types = [t.split(':') for t in hosted.types]
+            if hosted.types:
+                ns_types = [t.split(':') for t in hosted.types]
+            else:
+                ns_types = []
             h_descr = HostedServiceDescription(hosted.serviceId, endpoint_reference, self.log_prefix)
             self._hostedServices[hosted.serviceId] = h_descr
             h_descr.readMetadata(soapClient)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from codecs import open
 import os
 import subprocess
 
-version = '1.1.18'
+version = '1.1.19'
 
 # create a version.py file that is
 # a) used for __version__ info


### PR DESCRIPTION
Fixed a TypeError when trying to iterate over .types, which can be None, in case dpws:Hosted/Types is empty.