### PR TITLE
Hotfix for misinterpretation of SourceMds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the sdc11073 module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.21] - 2023-02-24
+### Fixed
+- SourceMds being interpreted as a state with an DescriptorHandle attribute
+
 ## [1.1.20] - 2022-12-12
 ### Fixed
 - AllowedValue.Value is not optional

--- a/sdc11073/mdib/msgreader.py
+++ b/sdc11073/mdib/msgreader.py
@@ -156,7 +156,7 @@ class MessageReader(object):
 
     def _mkStateContainersFromReportPart(self, reportPartNode):
         containers = []
-        for childNode in reportPartNode:
+        for childNode in reportPartNode.xpath('./*[not(self::msg:SourceMds)]', namespaces=namespaces.nsmap):
             desc_h = childNode.get('DescriptorHandle')
             if desc_h is None:
                 self._logger.error('{}_onEpisodicComponentReport: missing descriptor handle in {}!',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from codecs import open
 import os
 import subprocess
 
-version = '1.1.20'
+version = '1.1.21'
 
 # create a version.py file that is
 # a) used for __version__ info


### PR DESCRIPTION
SourceMds was being interpreted as a state with an DescriptorHandle attribute