### PR TITLE
128 wsdiscoverysingleadapter can not initialize when get ip for adapter returns none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the sdc11073 module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [tbd]
+
+### Fixed
+- fixed an error where 'str' object has no attribute 'nice_name' [#128](https://github.com/Draegerwerk/sdc11073/issues/128)
+
 ## [1.1.24] - 2023-04-16
 
 ### Added

--- a/src/sdc11073/netconn/__init__.py
+++ b/src/sdc11073/netconn/__init__.py
@@ -1,28 +1,101 @@
+"""This module contains functions to get the hosts network adapters and ip addresses."""
+
+import ipaddress
+import typing
+
 import ifaddr
 
-_IP_BLACKLIST = ('0.0.0.0', None)  # None can happen if an adapter does not have any IP address
+_IP_BLACKLIST = ("0.0.0.0", None)  # None can happen if an adapter does not have any IP address
 
 
-def get_ipv4_ips():
-    """returns a list of ifaddr._shared.IP objects (ip, nice_name, network_prefix)"""
-    ips = []
-    all_adapters = ifaddr.get_adapters()
-    for adapter in all_adapters:
-        for adapter.ip in adapter.ips:
-            if adapter.ip.is_IPv4 and adapter.ip.ip not in _IP_BLACKLIST:
-                ips.append(adapter.ip)
-    return ips
+class NetworkAdapterNotFoundError(Exception):
+    """Exception raised if no network adapter is found."""
+
+    def __init__(self, available_adapters: typing.List["NetworkAdapter"], *args):
+        """
+        :param available_adapters: adapters available on the host
+        """
+        super().__init__(*args)
+        self.available_adapters = available_adapters
 
 
-def get_ipv4_addresses():
-    """returns ip addresses"""
-    return [ip.ip for ip in get_ipv4_ips()]
+class NetworkAdapter(ipaddress.IPv4Interface):
+    """Represents a network adapter."""
+
+    def __init__(self, name: str, description: str, address: str, network_prefix: str):
+        """
+        :param name: name of the interface
+        :param description: descriptive, more general name of the network adapter
+        :param address: ip address of the network adapter
+        :param network_prefix: network prefix.
+        """
+        super().__init__(f"{address}/{network_prefix}")
+        self.name: str = name
+        self.description: str = description
+
+    def __str__(self) -> str:
+        return f"{self.name}: {super().__str__()}"
 
 
-def get_ip_for_adapter(adapter_name):
-    """returns a single ip address or None"""
-    ip_objects = get_ipv4_ips()
-    for ip_object in ip_objects:
-        if ip_object.nice_name == adapter_name:
-            return ip_object.ip
-    return None
+def get_adapters() -> typing.List[NetworkAdapter]:
+    """
+    Get all active and connected host network adapters.
+
+    :return: list of enabled and connected network adapters on the host
+    """
+    adapters: typing.List[NetworkAdapter] = []
+    for adapter in ifaddr.get_adapters():
+        for ip in adapter.ips:
+            if ip.is_IPv4:
+                adapters.append(NetworkAdapter(name=ip.nice_name,
+                                               description=adapter.nice_name,
+                                               address=ip.ip,
+                                               network_prefix=str(ip.network_prefix)))
+
+    return adapters
+
+
+def get_adapter_by_ip(ip: typing.Union[ipaddress.IPv4Address, str]) -> NetworkAdapter:
+    """
+    Get host network adapter containing the specified ip address in its network range.
+
+    :param ip: ip address from which the adapter is to be determined
+    :return: host network adapter containing the specified ip address in its network range
+    :raise NetworkAdapterNotFoundError if no network adapter contains the specified ip
+    :raise RuntimeError if multiple network adapter containing the specified ip
+    """
+    ip = ipaddress.IPv4Address(ip) if isinstance(ip, str) else ip
+
+    adapters = get_adapters()
+    filtered_adapters = [adapter for adapter in adapters if ip in adapter.network]
+
+    if not filtered_adapters:
+        raise NetworkAdapterNotFoundError(adapters, f'No host network adapter found that contains ip address "{ip}"')
+
+    if len(filtered_adapters) > 1:
+        raise RuntimeError(f'Found multiple host network adapters for ip address "{ip}". '
+                           f'Please disable one of the following adapters: {filtered_adapters}')
+
+    return filtered_adapters[0]
+
+
+def get_adapter_by_name(name: str) -> NetworkAdapter:
+    """
+    Get host network adapter by the specified name.
+
+    :param name: name of the adapter is to be determined
+    :return: host network adapter with the specified name
+    :raise NetworkAdapterNotFoundError if no network adapter has the specified name
+    :raise RuntimeError if multiple network adapter have the specified name
+    """
+    adapters = get_adapters()
+    filtered_adapters = [adapter for adapter in adapters if adapter.name == name]
+
+    if not filtered_adapters:
+        raise NetworkAdapterNotFoundError(adapters, f'No host network adapter found with the name "{name}"')
+
+    if len(filtered_adapters) > 1:
+        raise RuntimeError(f'Found multiple host network adapters with the name "{name}". '
+                           f'Please disable one of the following adapters: {filtered_adapters}')
+
+    return filtered_adapters[0]

--- a/src/sdc11073/sdcclient/sdcclientimpl.py
+++ b/src/sdc11073/sdcclient/sdcclientimpl.py
@@ -255,7 +255,7 @@ class SdcClient(object):
         return self._my_ipaddress
 
     def _findBestOwnIpAddress(self):
-        myIpAddresses = netconn.get_ipv4_addresses()
+        myIpAddresses = [str(adapter.ip) for adapter in netconn.get_adapters()]
 
         splitted = urlsplit(self._devicelocation)
         sortIPAddresses(myIpAddresses, splitted.hostname)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from sdc11073 import wsdiscovery
+from sdc11073 import wsdiscovery, netconn
 import logging
 import time
 import urllib
@@ -365,7 +365,7 @@ class TestDiscovery(unittest.TestCase):
                                                            multicast_port=self.MY_MULTICAST_PORT)
         wsd_service_all.start()
         time.sleep(0.1)
-        all_addresses = wsdiscovery.get_ipv4_addresses()
+        all_addresses = [str(adapter.ip) for adapter in netconn.get_adapters()]
         unicast_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
             # wsd_service_all listens on all ports, all udp uni cast messages shall be handled

--- a/tests/test_netconn.py
+++ b/tests/test_netconn.py
@@ -1,0 +1,128 @@
+"""
+Test for the netconn module.
+"""
+
+import ipaddress
+import typing
+import unittest
+import uuid
+from unittest import mock
+
+import ifaddr
+
+from sdc11073 import netconn
+
+
+class NetworkTest(unittest.TestCase):
+    """
+    Test methods contained in the netconn module.
+    """
+
+    def setUp(self):
+        """
+        Set up platform independent test variables.
+        """
+        self.ip_addresses: typing.List[typing.Tuple[str, int]] = \
+            [('192.168.0.1', 24), ('10.10.0.1', 32), ('127.0.0.1', 24)]
+        self.expected_adapters: typing.List[ifaddr.Adapter] = []
+
+        for ip, network_prefix in self.ip_addresses:
+            ips = [ifaddr.IP(ip=ip, network_prefix=network_prefix, nice_name=f'{uuid.uuid4().hex}')]
+            self.expected_adapters.append(ifaddr.Adapter(name='', nice_name=f'{uuid.uuid4().hex}', ips=ips))
+
+    def _verify_adapter_unique_ip(self):
+        """
+        Verify that every adapter has a unique ip address.
+        """
+        self.assertEqual(len({ip.ip for ip in self._expected_ips()}), len(self.expected_adapters))
+
+    def _expected_ips(self) -> typing.List[ifaddr.IP]:
+        """
+        Get the ips from the expected adapters.
+
+        :return: ips from expected adapters.
+        """
+        # contains lists of ip addresses for each adapter, e.g. [['..', '...'],['...']]
+        list_of_ip_lists = [adapter.ips for adapter in self.expected_adapters]
+
+        # flattens the list of lists and creating a single list containing each entry of the sublists
+        return [ip for ips in list_of_ip_lists for ip in ips]
+
+    def test_correct_ips_from_network(self):
+        """
+        Test whether the correct ips are determined when providing a subnet.
+        """
+        self._verify_adapter_unique_ip()
+        with mock.patch.object(ifaddr, 'get_adapters', return_value=self.expected_adapters):
+            adapters = netconn.get_adapters()
+            for adapter in adapters:
+                self.assertEqual(adapter.ip, netconn.get_adapter_by_ip(adapter.ip).ip)
+
+        # now, only one adapter with a very restricted range is available
+        nice_name = uuid.uuid4().hex
+        ips = [ifaddr.IP(ip='127.0.0.1', network_prefix=32, nice_name=nice_name)]
+        self.expected_adapters = [ifaddr.Adapter(name='', nice_name=f'description 1', ips=ips)]
+
+        with mock.patch.object(ifaddr, 'get_adapters', return_value=self.expected_adapters):
+            netconn.get_adapter_by_ip(ipaddress.IPv4Address('127.0.0.1'))  # verify no error
+            netconn.get_adapter_by_name(nice_name)  # verify no error
+            with self.assertRaises(netconn.NetworkAdapterNotFoundError):
+                netconn.get_adapter_by_ip(ipaddress.IPv4Address('127.0.0.2'))
+            with self.assertRaises(netconn.NetworkAdapterNotFoundError):
+                netconn.get_adapter_by_name(f'{nice_name}x')
+
+    def test_correct_parsing_of_config(self):
+        """
+        Test whether the network adapter config is parsed correctly.
+        """
+        self._verify_adapter_unique_ip()
+        with mock.patch.object(ifaddr, 'get_adapters', return_value=self.expected_adapters):
+            adapters = netconn.get_adapters()
+            self.assertEqual(len(adapters), len(self._expected_ips()))
+            for expected_ip in self._expected_ips():
+                expected_adapter: ifaddr.Adapter = \
+                    next(adap for adap in self.expected_adapters if expected_ip.ip in [ip.ip for ip in adap.ips])
+                actual_adapter: netconn.NetworkAdapter = \
+                    next(adapter for adapter in adapters if str(adapter.ip) == expected_ip.ip)
+                self.assertEqual(expected_ip.ip, str(actual_adapter.ip))
+                self.assertEqual(expected_ip.nice_name, actual_adapter.name)
+                self.assertEqual(expected_adapter.nice_name, actual_adapter.description)
+
+    def test_error_when_multiple_ips_on_same_subnet(self):
+        """
+        Test whether an exception is thrown when multiple ip addresses from the same subnet are detected.
+        """
+        additional_ips = [('10.1.1.1', 24), ('10.1.1.2', 24)]
+        ips_only = []
+        for ip, network_prefix in additional_ips:
+            ips = [ifaddr.IP(ip=ip, network_prefix=network_prefix, nice_name=f'{uuid.uuid4().hex}')]
+            self.expected_adapters.append(ifaddr.Adapter(name='', nice_name=f'{uuid.uuid4().hex}', ips=ips))
+            ips_only.append(ip)
+
+        self._verify_adapter_unique_ip()
+        with mock.patch.object(ifaddr, 'get_adapters', return_value=self.expected_adapters):
+            for adapter in [ip for ip in self._expected_ips() if ip.ip not in ips_only]:
+                netconn.get_adapter_by_ip(adapter.ip)  # ensure throws no error
+            for adapter in [ip for ip in self._expected_ips() if ip.ip in ips_only]:
+                with self.assertRaises(RuntimeError):
+                    netconn.get_adapter_by_ip(adapter.ip)
+
+    def test_multiple_ip_address_on_single_adapter(self):
+        """
+        Test whether multiple ip addresses on a single network interface do not throw an error.
+        """
+        expected_name = str(uuid.uuid4())
+        expected_description = str(uuid.uuid4())
+
+        expected_ips: typing.List[typing.Tuple[str, int]] = [('127.0.0.1', 24), ('127.0.1.1', 24)]
+        ips: typing.List[ifaddr.IP] = []
+        for ip, network_prefix in expected_ips:
+            ips.append(ifaddr.IP(ip=ip, network_prefix=network_prefix, nice_name=expected_name))
+        self.expected_adapters = [ifaddr.Adapter(name='', nice_name=expected_description, ips=ips)]
+
+        with mock.patch.object(ifaddr, 'get_adapters', return_value=self.expected_adapters):
+            for ip in [ipaddress.IPv4Address(i[0]) for i in expected_ips]:
+                actual_adapter = netconn.get_adapter_by_ip(ip)
+                self.assertEqual(expected_name, actual_adapter.name)
+                self.assertEqual(expected_description, actual_adapter.description)
+                self.assertEqual(ip, actual_adapter.ip)


### PR DESCRIPTION
reworked `netconn` module

## Description
reworked netconn module in order to fix #128 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#128 

## Motivation and Context
strongly typed network adapter

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tests have been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the [changelog](../CHANGELOG.md) accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
