### PR TITLE
alert provider role sends self check one second before time elapsed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - basic_logging_setup only handles sdc logger, no more side effect due to calling logging.basicConfig. 
-- 
+
 ### Changed
 - change python classes of `addressing_types.py` to match ws-addressing standard of 2006 instead of 2004 
 - The final OperationInvokedReport has OperationTargetRef parameter set. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- added a way to proccess operations sync (directly send FINISHED)
+- added a way to process operations directly (directly send 'Fin' instead of Wait, Started,...)
 
 ### Fixed
 - basic_logging_setup only handles sdc logger, no more side effect due to calling logging.basicConfig. 
-
+- 
 ### Changed
 - change python classes of `addressing_types.py` to match ws-addressing standard of 2006 instead of 2004 
 - The final OperationInvokedReport has OperationTargetRef parameter set. 
   This required refactoring of Operations handling.
 - moved waveform generator from mdib to roles.waveformprovider
+- alert provider performs self check one second before SelfCheckInterval elapses
 
 ## [2.0.0a6] - 2023-09-11
 

--- a/src/sdc11073/roles/alarmprovider.py
+++ b/src/sdc11073/roles/alarmprovider.py
@@ -32,6 +32,7 @@ class GenericAlarmProvider(providerbase.ProviderRole):
     """
 
     WORKER_THREAD_INTERVAL = 1.0  # seconds
+    self_check_safety_margin = 1.0 # how many seconds before SelfCheckInterval elapses a new self check is performed.
 
     def __init__(self, mdib: ProviderMdib, log_prefix: str):
         super().__init__(mdib, log_prefix)
@@ -409,10 +410,10 @@ class GenericAlarmProvider(providerbase.ProviderRole):
                 alert_system_state = self._mdib.states.descriptor_handle.get_one(alert_system_descr.Handle,
                                                                                  allow_none=True)
                 if alert_system_state is not None:
-                    selfcheck_period = alert_system_descr.SelfCheckPeriod
-                    if selfcheck_period is not None:
-                        last_selfcheck = alert_system_state.LastSelfCheck or 0.0
-                        if time.time() - last_selfcheck >= selfcheck_period:
+                    self_check_period = alert_system_descr.SelfCheckPeriod
+                    if self_check_period is not None:
+                        last_self_check = alert_system_state.LastSelfCheck or 0.0
+                        if time.time() - last_self_check >= self_check_period - self.self_check_safety_margin:
                             states_needing_update.append(alert_system_state)
         except Exception:
             exc = traceback.format_exc()


### PR DESCRIPTION
Send self check data a little earlier than SelfCheckPeriod, that helps to avoid timeouts on consumer side. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the [changelog](../CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.