### PR TITLE
Fix `address already in use` error in `NetworkingThreadPosix` on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `address already in use` error from `NetworkingThreadPosix` on macOS
 - possible exception in ConsumerMdib._get_context_states [#350](https://github.com/Draegerwerk/sdc11073/issues/350)
 - reference tests and example provider
 - node member of DescriptorContainer not updated on description modification report [#357](https://github.com/Draegerwerk/sdc11073/issues/357)

--- a/src/sdc11073/wsdiscovery/networkingthread.py
+++ b/src/sdc11073/wsdiscovery/networkingthread.py
@@ -345,6 +345,7 @@ class NetworkingThreadPosix(_NetworkingThreadBase):
     def _create_multicast_in_socket(self, addr: str, port: int) -> socket.SocketType:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         sock.bind((MULTICAST_IPV4_ADDRESS, port))
         sock.setblocking(False)
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, self._make_mreq(addr))
@@ -354,6 +355,7 @@ class NetworkingThreadPosix(_NetworkingThreadBase):
     def _create_unicast_in_socket(self, addr: str, port: int) -> socket.SocketType:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         sock.bind((addr, port))
         sock.setblocking(False)
         return sock


### PR DESCRIPTION
If #330 is merged, this PR might be obsolete.

<!--- Provide a general summary of your changes in the title above -->
<!--- Link the corresponding issues after you created the pull request -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the [changelog](../CHANGELOG.md) accordingly.
- [ ] I have added tests to cover my changes.

I don't know how to properly test this and am open for suggestions.