### PR TITLE
fix(provider): always initialise _end_to_url so unsubscribe does not crash

### DIFF
--- a/src/sdc11073/provider/subscriptionmgr_base.py
+++ b/src/sdc11073/provider/subscriptionmgr_base.py
@@ -109,13 +109,16 @@ class SubscriptionBase:
         self.notify_ref_params = subscribe_request.Delivery.NotifyTo.ReferenceParameters
         self.end_to_address = None
         self.end_to_ref_params = []
+        # Always initialise _end_to_url. A SubscribeRequest without an EndTo
+        # block is valid per the spec; the async send-end path reads
+        # self._end_to_url unconditionally and would otherwise raise
+        # AttributeError on unsubscribe. See #475.
+        self._end_to_url = None
         if subscribe_request.EndTo is not None:
             self.end_to_address = subscribe_request.EndTo.Address
             self.end_to_ref_params = subscribe_request.EndTo.ReferenceParameters
             if self.end_to_address is not None:
                 self._end_to_url = urlparse(self.end_to_address)
-            else:
-                self._end_to_url = None
 
         self.identifier_uuid = uuid.uuid4()
         self.reference_parameters = []  # default: no reference parameters


### PR DESCRIPTION
### Problem

`Subscription.__init__` only sets `self._end_to_url` inside the
`if subscribe_request.EndTo is not None:` branch. A SubscribeRequest
without an `EndTo` block is valid per the spec, and subscriptions
created from one therefore never acquire the attribute.

Later, on unsubscribe, the async end-message path reads it
unconditionally:

```python
# subscriptionmgr_async.py:105
url = self._end_to_url or self.notify_to_url
```

and raises:

```
AttributeError: 'BicepsSubscriptionAsync' object has no attribute '_end_to_url'
```

Reproduced per #475: subscribe without `EndTo`, then unsubscribe.

### Fix

Initialise `self._end_to_url = None` unconditionally, alongside
`end_to_address` / `end_to_ref_params`, before the `EndTo` branch. The
existing fallback

```python
url = self._end_to_url or self.notify_to_url
```

now behaves as intended: when there was no `EndTo`, the end-message is
sent to `notify_to_url`.

Minimal diff, no behaviour change for subscribers that do supply an
`EndTo`.

Fixes #475
